### PR TITLE
fix: linting is broken if dependant project doesn't have `postcss-scss` package in deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     plugins: ['stylelint-scss'],
-    customSyntax: 'postcss-scss',
+    customSyntax: require('postcss-scss'),
     rules: {
         // Possible errors
         'color-no-invalid-hex': true,


### PR DESCRIPTION
![image](https://github.com/gravity-ui/stylelint-config/assets/17454987/cecf91ca-2cde-407e-9c8c-0b9e19d9a193)
