### PR TITLE
Add exception for value-no-vendor-prefix rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,13 @@ module.exports = {
 
         // Limit language features
         'color-named': 'never',
-        'value-no-vendor-prefix': true,
+        'value-no-vendor-prefix': [
+			true,
+			{
+				// `-webkit-box` is allowed as standard. See https://www.w3.org/TR/css-overflow-3/#webkit-line-clamp
+				ignoreValues: ['box'],
+			},
+		],
         'property-no-vendor-prefix': true,
         'declaration-no-important': true,
         'declaration-block-single-line-max-declarations': 1,


### PR DESCRIPTION
`-webkit-box` is allowed as standard. See https://www.w3.org/TR/css-overflow-3/#webkit-line-clamp
				
Improvement based on stylelint-config-standard issue and PR
https://github.com/stylelint/stylelint/issues/6372
https://github.com/stylelint/stylelint-config-standard/pull/261/files


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.